### PR TITLE
Add placeholder ‘Category’ for dropdown in Budget Tracker and Packing List

### DIFF
--- a/src/components/ PackingList.jsx
+++ b/src/components/ PackingList.jsx
@@ -11,14 +11,14 @@ const categories = [
 function PackingList({ packingList, updatePackingList }) {
   const [newItem, setNewItem] = useState({
     name: "",
-    category: "Clothes",
+    category: "",
     packed: false,
   });
 
   const handleAddItem = () => {
-    if (newItem.name) {
+    if (newItem.name && newItem.category) {
       updatePackingList([...packingList, { ...newItem, id: Date.now() }]);
-      setNewItem({ name: "", category: "Clothes", packed: false });
+      setNewItem({ name: "", category: "", packed: false });
     }
   };
 
@@ -50,6 +50,9 @@ function PackingList({ packingList, updatePackingList }) {
           value={newItem.category}
           onChange={(e) => setNewItem({ ...newItem, category: e.target.value })}
         >
+          <option value="" disabled>
+            Category
+          </option>
           {categories.map((category) => (
             <option key={category} value={category}>
               {category}
@@ -63,7 +66,7 @@ function PackingList({ packingList, updatePackingList }) {
           Add Item
         </button>
       </div>
-      <hr className="border-2 my-4 border-[#FBFBEF]"></hr>
+      <hr className="border-2 my-4 border-[#FBFBEF]" />
       {categories.map((category) => (
         <div key={category}>
           <h4 className="font-bold">{category}</h4>

--- a/src/components/BudgetTracker.jsx
+++ b/src/components/BudgetTracker.jsx
@@ -13,11 +13,11 @@ function BudgetTracker({ budget, updateBudget }) {
   const [newExpense, setNewExpense] = useState({
     description: "",
     amount: "",
-    category: "Accommodation",
+    category: "Category", // Initial placeholder
   });
 
   const handleAddExpense = () => {
-    if (newExpense.description && newExpense.amount) {
+    if (newExpense.description && newExpense.amount && newExpense.category !== "Category") {
       const updatedBudget = {
         ...budget,
         expenses: [
@@ -30,7 +30,7 @@ function BudgetTracker({ budget, updateBudget }) {
         ],
       };
       updateBudget(updatedBudget);
-      setNewExpense({ description: "", amount: "", category: "Accommodation" });
+      setNewExpense({ description: "", amount: "", category: "Category" });
     }
   };
 
@@ -82,6 +82,9 @@ function BudgetTracker({ budget, updateBudget }) {
             setNewExpense({ ...newExpense, category: e.target.value })
           }
         >
+          <option value="Category" disabled>
+            Category
+          </option>
           {expenseCategories.map((category) => (
             <option key={category} value={category}>
               {category}


### PR DESCRIPTION
This PR introduces a placeholder "Category" option in the dropdown menus for both the **Budget Tracker** and **Packing List** components. By default, the "Category" placeholder helps guide users to select the appropriate category when adding an expense or packing item.

### Changes
- Added "Category" as the initial option in the dropdown for both Budget Tracker and Packing List.
- Preserved all existing functionality without altering any other features.

### Linked Issue
Closes #3
