### PR TITLE
Fix: Prevent end date selection earlier than start date

### DIFF
--- a/src/components/TripForm.jsx
+++ b/src/components/TripForm.jsx
@@ -30,13 +30,20 @@ function TripForm({ addTrip }) {
         className="rounded-lg p-1 pl-3 text-[24px] lg:text-[36px] text-[#151E41] focus:outline-[#151E41]"
         type="date"
         value={startDate}
-        onChange={(e) => setStartDate(e.target.value)}
+        onChange={(e) => {
+          setStartDate(e.target.value);
+          // Reset endDate if the new startDate is greater
+          if (e.target.value > endDate) {
+            setEndDate(""); // Clear endDate if startDate changes to a later date
+          }
+        }}
         required
       />
       <input
         className="rounded-lg p-1 pl-3 text-[24px] lg:text-[36px] text-[#151E41] focus:outline-[#151E41]"
         type="date"
         value={endDate}
+        min={startDate} // Set minimum date for end date based on selected start date
         onChange={(e) => setEndDate(e.target.value)}
         required
       />


### PR DESCRIPTION
This PR addresses the issue where users could select an end date that is earlier than the start date when adding a new trip. 

## Changes Made
- Implemented a `min` attribute on the end date input field to ensure users can only select a date that is equal to or later than the selected start date.
- Added logic to clear the end date if the start date is updated to a later date, preventing invalid selections.

## Related Issue
- This PR solves issue #9.